### PR TITLE
update IA Block template to follow Drupal/Twig standards, remove bootstrap classes

### DIFF
--- a/modules/localgov_homepage_paragraphs/templates/paragraph--localgov-ia-block.html.twig
+++ b/modules/localgov_homepage_paragraphs/templates/paragraph--localgov-ia-block.html.twig
@@ -39,18 +39,30 @@
  */
 #}
 
-{% if promoted %}
-<div class="services--business services--list-block mb-5 col-12">
-	<h2>
-		<a href="{{ field_link }}">{{ content.localgov_ia_block_title }}</a>
-	</h2>
-	{{ list }}
+{% 
+  set classes = [
+    'ia-block',
+    promoted ? 'ia-block--promoted'
+  ]
+%}
+
+<div{{ attributes.addClass(classes)}}>
+	{# Check if we have a title so we don't print an empty H2 #}
+  {% if paragraph.localgov_ia_block_title.value %}
+    <h2>
+			{# Don't print a anchor tag unless the title is linked #}
+    {% if field_link %}
+      <a href="{{ field_link }}">{{ content.localgov_ia_block_title }}</a>
+    {% else %}
+      {{ content.localgov_ia_block_title }}
+    {% endif %}
+    </h2>
+  {% endif %}
+
+	{# 
+		Render the list of links 
+		- this variable is created in localgov_homepage_paragraphs.module 
+	#}
+  {{ list }}
+	
 </div>
-{% else %}
-<div class="services--list-block mt-4 col-sm-6 col-md-4">
-	<h2>
-		<a href="{{ field_link }}">{{ content.localgov_ia_block_title }}</a>
-	</h2>
-	{{ list }}
-</div>
-{% endif %}

--- a/modules/localgov_homepage_paragraphs/templates/paragraph--localgov-ia-block.html.twig
+++ b/modules/localgov_homepage_paragraphs/templates/paragraph--localgov-ia-block.html.twig
@@ -66,3 +66,12 @@
   {{ list }}
 
 </div>
+
+{% block content_variable %}
+  {#
+    This allows the cache_context to bubble up for us, without having to
+    individually list every field in
+    {{ content|without('field_name', 'field_other_field', 'field_etc') }}
+  #}
+  {% set catch_cache = content|render %}
+{% endblock %}

--- a/modules/localgov_homepage_paragraphs/templates/paragraph--localgov-ia-block.html.twig
+++ b/modules/localgov_homepage_paragraphs/templates/paragraph--localgov-ia-block.html.twig
@@ -49,10 +49,10 @@
 <div{{ attributes.addClass(classes)}}>
 	{# Check if we have a title so we don't print an empty H2 #}
   {% if paragraph.localgov_ia_block_title.value %}
-    <h2>
+    <h2 class="ia-block__title">
 			{# Don't print a anchor tag unless the title is linked #}
     {% if field_link %}
-      <a href="{{ field_link }}">{{ content.localgov_ia_block_title }}</a>
+      <a class="ia-block__title-link" href="{{ field_link }}">{{ content.localgov_ia_block_title }}</a>
     {% else %}
       {{ content.localgov_ia_block_title }}
     {% endif %}
@@ -64,5 +64,5 @@
 		- this variable is created in localgov_homepage_paragraphs.module 
 	#}
   {{ list }}
-	
+
 </div>


### PR DESCRIPTION
I am working my way through theming LocalGovDrupal, but keep coming across hard-coded classes and things like that in module templates, which is making things quite difficult, such as this
services--business services--list-block mb-5 col-12
in
web/modules/contrib/localgov_paragraphs/modules/localgov_homepage_paragraphs/templates/paragraph--localgov-ia-block.html.twig
The issue that causes is it presumes the IA Block will always be placed in a 100% width space, and not in, for example, a 3-column layout. If you put an IA Block in a 3-column layout, then it’s not taking up the full 33% of the screen, it takes up 5/12 of the available space.

Whilst we may not necessarily use what I am proposing in this PR (for example, the CSS that is currently in the module doesn't work with my classes), I think this approach is a much more "Drupal way" of doing frontend, and certainly more scalable since the frontend does not mean every theme needs bootstrap, and each component's width can be defined by the container it is in rather that forcing widths on it.