### PR TITLE
Localgov module dependencies to non-alpha.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "drupal/geolocation": "^3.1",
         "drupal/office_hours": "^1.2",
         "drupal/paragraphs": "^1.11",
-        "localgovdrupal/localgov_core": "^1.0@alpha",
-        "localgovdrupal/localgov_topics": "^1.0@alpha"
+        "localgovdrupal/localgov_core": "^1.0",
+        "localgovdrupal/localgov_topics": "^1.0"
     },
     "extra": {
         "enable-patching": true,


### PR DESCRIPTION
Further to localgovdrupal/localgov#200 tidy up composer dependencies to the now existing 1.x versions.