### PR TITLE
PR ahead of 2.0.1 release to include urgent bug fix for Drupal office_hours schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
           composer global config github-oauth.github.com ${{ github.token }}
 
       - name: Obtain the test target from the repo that triggered this workflow
-        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE}-dev"
+        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE%'.x'}"
         
   phpcs:
     name: Coding standards checks

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,10 @@
         "patches": {
             "drupal/geolocation": {
                 "Fix schema #3138668": "https://www.drupal.org/files/issues/2021-01-27/geolocation-google-maps-schema-update-3138668-5.patch"
-            }
+            },
+	    "drupal/office_hours": {
+	        "Update office_hours field config schema": "https://git.drupalcode.org/project/office_hours/-/merge_requests/3/diffs.patch"
+	    }
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "drupal/field_group": "^3.0",
         "drupal/fontawesome": "2.x-dev#0a02cad1",
         "drupal/geolocation": "^3.1",
-        "drupal/office_hours": "^1.2",
+        "drupal/office_hours": "^1.4",
         "drupal/paragraphs": "^1.11",
         "localgovdrupal/localgov_core": "^2.0",
         "localgovdrupal/localgov_topics": "^1.0"

--- a/config/install/field.storage.paragraph.localgov_contact_office_hours.yml
+++ b/config/install/field.storage.paragraph.localgov_contact_office_hours.yml
@@ -13,8 +13,10 @@ settings:
   time_format: G
   element_type: office_hours_datelist
   increment: 15
-  comment: false
+  comment: 0
   valhrs: false
+  required_start: false
+  required_end: false
   limit_start: ''
   limit_end: ''
 module: office_hours


### PR DESCRIPTION
We need to get this released to prevent tests failing on the office_hours schema like:

https://github.com/localgovdrupal/localgov_core/pull/91/checks?check_run_id=2830659197

See conversation on https://github.com/localgovdrupal/localgov_paragraphs/pull/33