### PR TITLE
Remove office hours patch as it has been added to the module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,7 @@
         "patches": {
             "drupal/geolocation": {
                 "Fix schema #3138668": "https://www.drupal.org/files/issues/2021-01-27/geolocation-google-maps-schema-update-3138668-5.patch"
-            },
-	    "drupal/office_hours": {
-	        "Update office_hours field config schema": "https://git.drupalcode.org/project/office_hours/-/merge_requests/3/diffs.patch"
-	    }
+            }
         }
     }
 }


### PR DESCRIPTION
Tests are now failing because @finnlewis 's patch to the Office hours module has been committed and applying the patch again replicates the `office_hours_update_8003` function.

Once this has been approved we'll need to do another release of this module to fix the tests.