### PR TITLE
Temporary fix for Contact paragraph add/edit form

### DIFF
--- a/config/install/core.entity_form_display.paragraph.localgov_contact.default.yml
+++ b/config/install/core.entity_form_display.paragraph.localgov_contact.default.yml
@@ -22,7 +22,7 @@ dependencies:
   module:
     - address
     - field_group
-    - geolocation
+    - geolocation_google_maps
     - link
     - office_hours
     - telephone
@@ -42,7 +42,7 @@ third_party_settings:
       format_settings:
         id: ''
         classes: ''
-        direction: vertical
+        direction: horizontal
       label: Tabs
     group_phone:
       children:

--- a/localgov_paragraphs.install
+++ b/localgov_paragraphs.install
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @file
+ * Update hooks.
+ */
+
+use Drupal\Core\Utility\UpdateException;
+
+/**
+ * Implements hook_update_N().
+ *
+ * Switching to horizontal tab from vertical tab for Contact paragraph.  This
+ * is to avoid a core bug.
+ *
+ * @see https://www.drupal.org/project/drupal/issues/3223319
+ */
+function localgov_paragraphs_update_9001() {
+
+  $contact_form_config = Drupal::service('entity_type.manager')->getStorage('entity_form_display')->load('paragraph.localgov_contact.default');
+  if (empty($contact_form_config)) {
+    return;
+  }
+
+  $top_tab_settings = $contact_form_config->getThirdPartySetting('field_group', 'group_contact_tabs');
+  if (empty($top_tab_settings)) {
+    return t('Cannot find tab configuration for Contact paragraph.');
+  }
+
+  $is_already_horizontal_tab = ($top_tab_settings['format_settings']['direction'] === 'horizontal');
+  if ($is_already_horizontal_tab) {
+    return t('Contact paragraph is already using horizontal tabs.  Nothing to update.');
+  }
+
+  $updated_top_tab_settings = $top_tab_settings;
+  $updated_top_tab_settings['format_settings']['direction'] = 'horizontal';
+
+  try {
+    $contact_form_config->setThirdPartySetting('field_group', 'group_contact_tabs', $updated_top_tab_settings);
+    $contact_form_config->save();
+  }
+  catch (Exception $e) {
+    throw new UpdateException($e->getMessage());
+  }
+
+  $magenta = "\033[35m";
+  $colour_off = "\033[0m";
+  return t("Switched Contact paragraph form display tab from vertical to horizontal tab.  Please %magenta**export site configuration**%colour_off.", [
+    '%magenta' => $magenta,
+    '%colour_off' => $colour_off,
+  ]);
+}

--- a/localgov_paragraphs.install
+++ b/localgov_paragraphs.install
@@ -43,8 +43,8 @@ function localgov_paragraphs_update_9001() {
     throw new UpdateException($e->getMessage());
   }
 
-  $magenta = "\033[35m";
-  $colour_off = "\033[0m";
+  $is_terminal = PHP_SAPI === 'cli' && getenv('TERM');
+  [$magenta, $colour_off] = $is_terminal ? ["\033[35m", "\033[0m"] : ['', ''];
   return t("Switched Contact paragraph form display tab from vertical to horizontal tab.  Please %magenta**export site configuration**%colour_off.", [
     '%magenta' => $magenta,
     '%colour_off' => $colour_off,

--- a/localgov_paragraphs.install
+++ b/localgov_paragraphs.install
@@ -45,8 +45,9 @@ function localgov_paragraphs_update_9001() {
 
   $is_terminal = PHP_SAPI === 'cli' && getenv('TERM');
   [$magenta, $colour_off] = $is_terminal ? ["\033[35m", "\033[0m"] : ['', ''];
-  return t("Switched Contact paragraph form display tab from vertical to horizontal tab.  Please %magenta**export site configuration**%colour_off.", [
+  return t("Switched Contact paragraph form display tab from vertical to horizontal tab.  Please %magenta%action-msg%colour_off.", [
     '%magenta' => $magenta,
     '%colour_off' => $colour_off,
+    '%action-msg' => '**export site configuration**',
   ]);
 }

--- a/tests/src/Functional/ContactEditTest.php
+++ b/tests/src/Functional/ContactEditTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\Tests\localgov_paragraphs\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Validates Contact Page component edit form.
+ *
+ * We should be able to edit Contact Page components.  Drupal core bugs
+ * shouldn't throw exceptions.
+ *
+ * @see https://www.drupal.org/project/drupal/issues/3223319
+ */
+class ContactEditTest extends BrowserTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'localgov_paragraphs',
+    'paragraphs_library',
+  ];
+
+  /**
+   * {@inheritdoc}
+   *
+   * Claro is throwing the exception.
+   */
+  protected $defaultTheme = 'claro';
+
+  /**
+   * {@inheritdoc}
+   *
+   * Create a Contact page component.
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $paragraph_storage = $this->container->get('entity_type.manager')->getStorage('paragraph');
+    $contact_paragraph = $paragraph_storage->create([
+      'type' => 'localgov_contact',
+      'localgov_contact_heading' => 'Foo',
+    ]);
+    $contact_paragraph->save();
+
+    $page_component_storage = $this->container->get('entity_type.manager')->getStorage('paragraphs_library_item');
+    $contact_page_component = $page_component_storage->create([
+      'label' => 'Foo',
+      'paragraphs' => $contact_paragraph,
+    ]);
+    $contact_page_component->save();
+
+    $this->drupalLogin($this->drupalCreateUser(['administer paragraphs library']));
+  }
+
+  /**
+   * Ensure we can edit Contact page components.
+   */
+  public function testContactPageComponentEditPage(): void {
+
+    $this->drupalGet('admin/content/paragraphs/1/edit');
+    $this->assertSession()->elementExists('css', '#edit-label-0-value');
+  }
+
+}


### PR DESCRIPTION
Contact Paragraph's form display should use horizontal tabs instead of vertical tabs.  These tabs are provided by the field_group module.

This is a temporary work around for a Drupal 9.x core bug involving the Claro theme.
@see https://www.drupal.org/project/drupal/issues/3223319

Resolves #40