### PR TITLE
Adjust test base class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/fontawesome": "2.x-dev#0a02cad1",
         "drupal/geolocation": "^3.1",
         "drupal/office_hours": "^1.4",
-        "drupal/paragraphs": "^1.11",
+        "drupal/paragraphs": "^1.13",
         "localgovdrupal/localgov_core": "^2.0",
         "localgovdrupal/localgov_topics": "^1.0"
     },

--- a/localgov_paragraphs.info.yml
+++ b/localgov_paragraphs.info.yml
@@ -20,7 +20,7 @@ dependencies:
   - geolocation:geolocation
   - geolocation:geolocation_google_maps
   - office_hours:office_hours
-  - paragraphs:paragraphs
+  - paragraphs:paragraphs (>=8.x-1.13)
   - paragraphs:paragraphs_library
   # LocalGovDrupal
   - localgov_core:localgov_media

--- a/tests/src/Functional/ParagraphsAdministrationTest.php
+++ b/tests/src/Functional/ParagraphsAdministrationTest.php
@@ -14,7 +14,7 @@ class ParagraphsAdministrationTest extends ParagraphsTestBase {
    *
    * @var array
    */
-  protected static $modules = [
+  public static $modules = [
     'localgov_paragraphs',
   ];
 

--- a/tests/src/Functional/ParagraphsAdministrationTest.php
+++ b/tests/src/Functional/ParagraphsAdministrationTest.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Tests\localgov_paragraphs\Functional;
 
-use Drupal\Tests\paragraphs\Functional\Classic\ParagraphsTestBase;
+use Drupal\Tests\paragraphs\Functional\WidgetLegacy\ParagraphsTestBase;
 
 /**
  * Tests the configuration of localgov_paragraphs.
@@ -14,7 +14,7 @@ class ParagraphsAdministrationTest extends ParagraphsTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'localgov_paragraphs',
   ];
 


### PR DESCRIPTION
The [ParagraphsTestBase](https://git.drupalcode.org/project/paragraphs/-/blob/8.x-1.x/tests/src/Functional/WidgetLegacy/ParagraphsTestBase.php) class file has been relocated in the latest release of the paragraphs module.  Previously it was in a [different directory](https://git.drupalcode.org/project/paragraphs/-/blob/8.x-1.12/tests/src/Functional/Classic/ParagraphsTestBase.php).  Adjusting our test class accordingly.

@see https://github.com/localgovdrupal/localgov_subsites/pull/75