### PR TITLE
Change font awesome to 2.18

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "drupal/entity_usage": "^2.0@beta",
         "drupal/field_formatter_class": "^1.4",
         "drupal/field_group": "^3.0",
-        "drupal/fontawesome": "2.x-dev#0a02cad1",
+        "drupal/fontawesome": "^2.18",
         "drupal/geolocation": "^3.1",
         "drupal/office_hours": "^1.4",
         "drupal/paragraphs": "^1.13",


### PR DESCRIPTION
Fix #39
Instead of pinning to a specific commit hash.
Using 2.18 as that is the release after the commit hash that was pinned.