### PR TITLE
Link paragraph: optionally display as a button style

### DIFF
--- a/config/install/core.entity_form_display.paragraph.localgov_link.default.yml
+++ b/config/install/core.entity_form_display.paragraph.localgov_link.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.localgov_link.localgov_link_style
     - field.field.paragraph.localgov_link.localgov_title
     - field.field.paragraph.localgov_link.localgov_url
     - paragraphs.paragraphs_type.localgov_link
@@ -10,22 +11,28 @@ targetEntityType: paragraph
 bundle: localgov_link
 mode: default
 content:
+  localgov_link_style:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   localgov_title:
+    type: string_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   localgov_url:
+    type: string_textfield
     weight: 1
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
 hidden:
   created: true
   status: true

--- a/config/install/core.entity_view_display.paragraph.localgov_link.default.yml
+++ b/config/install/core.entity_view_display.paragraph.localgov_link.default.yml
@@ -22,6 +22,7 @@ content:
     region: content
   localgov_title:
     type: string
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -29,6 +30,7 @@ content:
     region: content
   localgov_url:
     type: string
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }

--- a/config/install/core.entity_view_display.paragraph.localgov_link.default.yml
+++ b/config/install/core.entity_view_display.paragraph.localgov_link.default.yml
@@ -2,28 +2,39 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.localgov_link.localgov_link_style
     - field.field.paragraph.localgov_link.localgov_title
     - field.field.paragraph.localgov_link.localgov_url
     - paragraphs.paragraphs_type.localgov_link
+  module:
+    - options
 id: paragraph.localgov_link.default
 targetEntityType: paragraph
 bundle: localgov_link
 mode: default
 content:
+  localgov_link_style:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
   localgov_title:
-    weight: 0
+    type: string
     label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 0
     region: content
   localgov_url:
-    weight: 1
+    type: string
     label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 1
     region: content
-hidden: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/install/core.entity_view_display.paragraph.localgov_link.default.yml
+++ b/config/install/core.entity_view_display.paragraph.localgov_link.default.yml
@@ -22,7 +22,6 @@ content:
     region: content
   localgov_title:
     type: string
-    label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -30,7 +29,6 @@ content:
     region: content
   localgov_url:
     type: string
-    label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }

--- a/config/install/field.field.paragraph.localgov_link.localgov_link_style.yml
+++ b/config/install/field.field.paragraph.localgov_link.localgov_link_style.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.localgov_link_style
+    - paragraphs.paragraphs_type.localgov_link
+  module:
+    - options
+id: paragraph.localgov_link.localgov_link_style
+field_name: localgov_link_style
+entity_type: paragraph
+bundle: localgov_link
+label: 'Link style'
+description: 'Choose the style of the link. '
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.storage.paragraph.localgov_link_style.yml
+++ b/config/install/field.storage.paragraph.localgov_link_style.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.localgov_link_style
+field_name: localgov_link_style
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: button
+      label: Button
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Relates #92 

- Add an option on the Link paragraph to display as a link or a button style. 
- On the link paragraph type, add a select field named Link style, with the option button|Button and field description "Choose the style of the link".
- Import the changes.