### PR TITLE
Remove dependency on media_library_edit as using localgov_core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "drupal/fontawesome": "^2.18",
         "drupal/geolocation": "^3.1",
         "drupal/layout_paragraphs": "^2.0",
-        "drupal/media_library_edit": "^2.3",
         "drupal/office_hours": "^1.4",
         "drupal/paragraphs": "^1.13",
         "drupal/tablefield": "^2.3",


### PR DESCRIPTION
Fix #108 

Since we already depend on localgov_core, we don't need to include media_library_edit here. This should also allow the upgrade to be made in localgov_core.