### PR TITLE
Add check for heading level to be a string before calling _localgov_p…

### DIFF
--- a/modules/localgov_paragraphs_views/localgov_paragraphs_views.module
+++ b/modules/localgov_paragraphs_views/localgov_paragraphs_views.module
@@ -18,7 +18,9 @@ function localgov_paragraphs_views_preprocess_paragraph(&$variables) {
   if ($paragraph->hasField('localgov_heading_level') && $paragraph->hasField('localgov_title') && !$paragraph->get('localgov_title')->isEmpty()) {
     $heading_text = $paragraph->get('localgov_title')->value;
     $heading_level = $paragraph->get('localgov_heading_level')->value;
-    $variables['heading'] = _localgov_paragraphs_views_create_heading($heading_text, $heading_level);
+    if (is_string($heading_level)) {
+      $variables['heading'] = _localgov_paragraphs_views_create_heading($heading_text, $heading_level);
+    }
   }
 }
 

--- a/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.module
+++ b/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.module
@@ -118,7 +118,9 @@ function localgov_subsites_paragraphs_preprocess_paragraph(&$variables) {
   if ($paragraph->hasField('localgov_heading_level') && $paragraph->hasField('localgov_title') && !$paragraph->get('localgov_title')->isEmpty()) {
     $heading_text = $paragraph->get('localgov_title')->value;
     $heading_level = $paragraph->get('localgov_heading_level')->value;
-    $variables['heading'] = _localgov_subsites_paragraphs_create_heading($heading_text, $heading_level);
+    if (is_string($heading_level)) {
+      $variables['heading'] = _localgov_paragraphs_views_create_heading($heading_text, $heading_level);
+    }
   }
 
   if ($paragraph->bundle() === 'localgov_box_link') {


### PR DESCRIPTION
This is coming from https://github.com/localgovdrupal/localgov_paragraphs/issues/116

@tom-watson-croydon has a live issue where a page is not ediable due (I suspect) to heading level being unset on an embedded content listing paragraph.

This should fix #116 

Looks like the code was originally @msayoung but would welcome comment from anyone!



