### PR TITLE
Fix #137 missing layout paragraphs settings.

### DIFF
--- a/modules/localgov_paragraphs_layout/localgov_paragraphs_layout.post_update.php
+++ b/modules/localgov_paragraphs_layout/localgov_paragraphs_layout.post_update.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ *   Post update hooks for LocalGov Paragraphs Layout.
+ */
+
+/**
+ * Update, or create, Layout Paragraphs settings if they aren't yet set.
+ */
+function localgov_paragraphs_layout_post_update_fix_missing_layout_paragraphs_setting() {
+  $config = \Drupal::configFactory()->getEditable('layout_paragraphs.modal_settings');
+  $settings = $config->getRawData();
+  // Unlike config entities we're fine creating new config from getEditable,
+  // so just checking if these settings aren't set for whatever reason is safe.
+  if (empty($settings['width']) && empty($settings['height']) && empty($settings['autoresize'])) {
+    $config->set('width', '90');
+    $config->set('height', 'auto');
+    $config->set('autoresize', TRUE);
+    $config->save();
+  }
+}

--- a/modules/localgov_paragraphs_layout/localgov_paragraphs_layout.post_update.php
+++ b/modules/localgov_paragraphs_layout/localgov_paragraphs_layout.post_update.php
@@ -14,7 +14,7 @@ function localgov_paragraphs_layout_post_update_fix_missing_layout_paragraphs_se
   // Unlike config entities we're fine creating new config from getEditable,
   // so just checking if these settings aren't set for whatever reason is safe.
   if (empty($settings['width']) && empty($settings['height']) && empty($settings['autoresize'])) {
-    $config->set('width', '90');
+    $config->set('width', '90%');
     $config->set('height', 'auto');
     $config->set('autoresize', TRUE);
     $config->save();

--- a/modules/localgov_paragraphs_layout/localgov_paragraphs_layout.post_update.php
+++ b/modules/localgov_paragraphs_layout/localgov_paragraphs_layout.post_update.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- *   Post update hooks for LocalGov Paragraphs Layout.
+ * Post update hooks for LocalGov Paragraphs Layout.
  */
 
 /**


### PR DESCRIPTION
Guess the thing to test is:-

If you happen to have a db for a site with the broken modal run the update on it.
Otherwise maybe break it by deleting the config/sync/layout_paragraphs.modal_settings.php and drush cim to remove it, then running updates.
Also run updates on a good site, with different setting maybe, to check it doesn't change anything.

In all cases modal should have correct settings and work after the updat.