### PR TITLE
Makes the email addresses in contact components into proper mailto links (#127).

### DIFF
--- a/config/install/core.entity_view_display.paragraph.localgov_contact.default.yml
+++ b/config/install/core.entity_view_display.paragraph.localgov_contact.default.yml
@@ -42,7 +42,7 @@ content:
     label: inline
     settings: {  }
     third_party_settings: {  }
-    type: basic_string
+    type: email_mailto
     region: content
   localgov_contact_facebook:
     weight: 11


### PR DESCRIPTION
Does what @keelanfh was hoping for in #127 on new installations:

<img width="1250" alt="image" src="https://github.com/localgovdrupal/localgov_paragraphs/assets/158008/19b19d7d-0610-41e1-8c49-e68cedee2194">


This will work on new installations, but I opted not to add an update hook in case it breaks other sites' configurations. Is that a fair assumption to make, or shall I add an update hook after all?