### PR TITLE
Allow address module to upgrade.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
+          - '8.2'
 
     steps:
 
@@ -105,13 +105,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
+          - '8.2'
 
     steps:
 
@@ -141,13 +141,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
+          - '8.2'
 
     steps:
 
@@ -176,13 +176,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
+          - '8.2'
 
     steps:
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "minimum-stability": "dev",
     "require": {
         "cweagans/composer-patches": "^1.6",
-        "drupal/address": "^1.8",
+        "drupal/address": "^1.8 || ^2.0",
         "drupal/crop": "^2.1",
         "drupal/entity_browser": "^2.5",
         "drupal/entity_usage": "^2.0@beta",


### PR DESCRIPTION
Address module has a 2.0 version https://www.drupal.org/project/address/releases/2.0.0

I've just manually tested this with a contact paragraph (in a directory item) and it upgrades fine.
I've also already done this in geo_entity without issue.
Underlying changes are in their library. 

Biggest bonuses for LGD users upgrading are likely to be the optional third address line (space for ward/neighbourhood) and that you can set the container type for the address on the form in configuration.