### PR TITLE
feat: guards against RE-creating field config, storage config

### DIFF
--- a/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.install
+++ b/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.install
@@ -73,13 +73,17 @@ function localgov_subsites_paragraphs_update_10001() {
 
   foreach (array_merge($existingFields, $newFields) as $fieldName => $config) {
     if (array_key_exists($fieldName, $newFields)) {
-      // Field Storage.
-      $fieldStorage = FieldStorageConfig::create($config['field_storage']);
-      $fieldStorage->save();
+      if (!FieldStorageConfig::loadByName('paragraph', $fieldName)) {
+        // Field Storage.
+        $fieldStorage = FieldStorageConfig::create($config['field_storage']);
+        $fieldStorage->save();
+      }
 
-      // Field Config.
-      $fieldConfig = FieldConfig::create($config['field_config']);
-      $fieldConfig->save();
+      if (!FieldConfig::loadByName('paragraph', 'localgov_accordion', $fieldName)) {
+        // Field Config.
+        $fieldConfig = FieldConfig::create($config['field_config']);
+        $fieldConfig->save();
+      }
 
       // View Display.
       if ($viewDisplay) {
@@ -88,11 +92,10 @@ function localgov_subsites_paragraphs_update_10001() {
 
         if (!in_array($dependency, $dependencies, TRUE)) {
           $dependencies[] = $dependency;
+          $viewDisplay->set('dependencies', ['config' => $dependencies]);
+          $viewDisplay->removeComponent($fieldName);
+          $viewDisplay->save();
         }
-
-        $viewDisplay->set('dependencies', ['config' => $dependencies]);
-        $viewDisplay->removeComponent($fieldName);
-        $viewDisplay->save();
       }
 
       // Form Display.
@@ -107,10 +110,9 @@ function localgov_subsites_paragraphs_update_10001() {
             'region' => 'content',
             'settings' => ['display_label' => TRUE],
           ]);
+          $formDisplay->set('dependencies', ['config' => $dependencies]);
+          $formDisplay->save();
         }
-
-        $formDisplay->set('dependencies', ['config' => $dependencies]);
-        $formDisplay->save();
       }
     }
 


### PR DESCRIPTION
The original code [shouldn't fail in most cases](https://github.com/localgovdrupal/localgov_paragraphs/issues/195#issuecomment-2344390561), but if `drush cim` runs prior to `drush updb`, it will. The change prevents that from happening.

## What does this change?

Specifically, it verifies that the field config and field storage config are _not_ already present before making any changes.

## How to test

There are essentially two things that need testing:

1. Install `localgov_subsites`, on a site where it's not already installed, and create a subsite overview page with an accordion paragraph:
    - if successful, the two new fields (see Images, below) should be present in the paragraph edit form
2. Run the update hook on a site that already includes the new fields:
    - if successful, the update hook will run without erroring because the fields already exist 

## How can we measure success?

If the update hook doesn't cause problems :grimacing: 

## Images

![image](https://github.com/user-attachments/assets/e7204226-4816-4b91-bb64-a74ee893cd7c)

## Accessibility

N/A