### PR TITLE
Remove accordion icon added by JS and add to twig instead

### DIFF
--- a/modules/localgov_subsites_paragraphs/css/localgov-accordion.css
+++ b/modules/localgov_subsites_paragraphs/css/localgov-accordion.css
@@ -8,6 +8,10 @@
   text-align: left;
 }
 
+.accordion-pane__title button[hidden] {
+	display: none;
+}
+
 .accordion--initialised .accordion-pane__content {
   display: none;
 }

--- a/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
+++ b/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
@@ -117,17 +117,17 @@
           const pane = accordionPanes[i];
           const content = pane.querySelectorAll('.accordion-pane__content');
           const title = pane.querySelectorAll('.accordion-pane__title');
-          const titleText = title[0].textContent;
-          const button = document.createElement('button');
-          const text = document.createTextNode(titleText);
+          //const titleText = title[0].textContent;
+          const button = title.querySelectorAll('button');
+          //const text = document.createTextNode(titleText);
           const id = `accordion-content-${index}-${i}`;
 
           // Add id attribute to all pane content elements.
           content[0].setAttribute('id', id);
 
           // Add show/hide button to each accordion title.
-          button.appendChild(text);
-          button.setAttribute('aria-expanded', 'false');
+          //button.appendChild(text);
+         // button.setAttribute('aria-expanded', 'false');
           button.setAttribute('aria-controls', id);
 
           // Add click event listener to the show/hide button.

--- a/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
+++ b/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
@@ -124,6 +124,7 @@
           content[0].setAttribute('id', id);
 
           // Add aria-controls id to button
+          button.hidden = false;
           button.setAttribute('aria-controls', id);
 
           // Add click event listener to the show/hide button.
@@ -182,13 +183,14 @@
 
       const destroy = () => {
         for (let i = 0; i < numberOfPanes; i++) {
-          // Remove buttons from accordion pane titles.
+          // Remove id attributes from buttons in accordion pane titles.
           const button = accordion
-            .querySelectorAll('.accordion-pane__title')
-            [i].querySelectorAll('button');
-          if (button.length > 0) {
-            button[0].outerHTML = button[0].innerHTML;
-          }
+            .querySelectorAll('.accordion-pane__title')[i]
+            .querySelectorAll('button')
+            .removeAttribute('id');
+          
+          // Hide buttons in accordion pane titles.
+          button.hidden = true;
 
           // Remove id attributes from pane content elements.
           accordionPanes[i]

--- a/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
+++ b/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
@@ -125,9 +125,7 @@
           // Add id attribute to all pane content elements.
           content[0].setAttribute('id', id);
 
-          // Add show/hide button to each accordion title.
-          //button.appendChild(text);
-         // button.setAttribute('aria-expanded', 'false');
+          // Add aria-controls id to button
           button.setAttribute('aria-controls', id);
 
           // Add click event listener to the show/hide button.

--- a/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
+++ b/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
@@ -117,9 +117,7 @@
           const pane = accordionPanes[i];
           const content = pane.querySelectorAll('.accordion-pane__content');
           const title = pane.querySelectorAll('.accordion-pane__title');
-          //const titleText = title[0].textContent;
           const button = title.querySelectorAll('button');
-          //const text = document.createTextNode(titleText);
           const id = `accordion-content-${index}-${i}`;
 
           // Add id attribute to all pane content elements.

--- a/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
+++ b/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
@@ -117,7 +117,7 @@
           const pane = accordionPanes[i];
           const content = pane.querySelectorAll('.accordion-pane__content');
           const title = pane.querySelectorAll('.accordion-pane__title');
-          const button = title.querySelectorAll('button');
+          const button = title[0].querySelector('.accordion-pane-toggle');
           const id = `accordion-content-${index}-${i}`;
 
           // Add id attribute to all pane content elements.

--- a/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
+++ b/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
@@ -124,64 +124,67 @@
           // Add id attribute to all pane content elements.
           content[0].setAttribute('id', id);
 
-          // Add aria-controls id to button and un-hide
-          button.setAttribute('aria-controls', id);
-          button.hidden = false;
-
           // Hide default Heading text
-          heading.hidden = true;
+          if (heading) {  
+            heading.hidden = true;  
+          };
+          
+          if (button) {
+            // Add aria-controls id to button and un-hide
+            button.setAttribute('aria-controls', id);
+            button.hidden = false;
+          
+            // Add click event listener to the show/hide button.
+            button.addEventListener('click', e => {
+              const targetPaneId = e.target.getAttribute('aria-controls');
+              const targetPane = accordion.querySelectorAll(`#${targetPaneId}`);
+              const openPane = accordion.querySelectorAll(`.${openClass}`);
 
-          // Add click event listener to the show/hide button.
-          button.addEventListener('click', e => {
-            const targetPaneId = e.target.getAttribute('aria-controls');
-            const targetPane = accordion.querySelectorAll(`#${targetPaneId}`);
-            const openPane = accordion.querySelectorAll(`.${openClass}`);
+              // Check the current state of the button and the content it controls.
+              if (e.target.getAttribute('aria-expanded') === 'false') {
+                // Close currently open pane.
+                if (openPane.length && !allowMultiple) {
+                  const openPaneId = openPane[0].getAttribute('id');
+                  const openPaneButton = accordion.querySelectorAll(
+                    `[aria-controls="${openPaneId}"]`,
+                  );
 
-            // Check the current state of the button and the content it controls.
-            if (e.target.getAttribute('aria-expanded') === 'false') {
-              // Close currently open pane.
-              if (openPane.length && !allowMultiple) {
-                const openPaneId = openPane[0].getAttribute('id');
-                const openPaneButton = accordion.querySelectorAll(
-                  `[aria-controls="${openPaneId}"]`,
-                );
+                  collapsePane(openPaneButton[0], openPane[0]);
+                }
 
-                collapsePane(openPaneButton[0], openPane[0]);
+                // Show new pane.
+                expandPane(e.target, targetPane[0]);
+              } else {
+                // If target pane is currently open, close it.
+                collapsePane(e.target, targetPane[0]);
               }
 
-              // Show new pane.
-              expandPane(e.target, targetPane[0]);
-            } else {
-              // If target pane is currently open, close it.
-              collapsePane(e.target, targetPane[0]);
-            }
+              if (showHideButton) {
+                const accordionState = getAccordionState();
+                const toggleState = showHideButton.getAttribute('aria-expanded') === 'true';
 
-            if (showHideButton) {
-              const accordionState = getAccordionState();
-              const toggleState = showHideButton.getAttribute('aria-expanded') === 'true';
-
-              if (
-                (accordionState === 1 && !toggleState) ||
-                (!accordionState && toggleState)
-              ) {
-                toggleAll();
+                if (
+                  (accordionState === 1 && !toggleState) ||
+                  (!accordionState && toggleState)
+                ) {
+                  toggleAll();
+                }
               }
+            });
+          };
+
+          if (button) {
+            if (displayShowHide) {
+              showHideButton = accordion.querySelector('.accordion-toggle-all');
+              showHideButton.hidden = false;
+              showHideButton.addEventListener('click', toggleAll);
+              showHideButtonLabel = showHideButton.querySelector('.accordion-text');
             }
-          });
 
-          if (displayShowHide) {
-            showHideButton = accordion.querySelector('.accordion-toggle-all');
-            showHideButton.hidden = false;
-            showHideButton.addEventListener('click', toggleAll);
-            showHideButtonLabel = showHideButton.querySelector('.accordion-text');
-          }
+            // Add init class.
+            accordion.classList.add(initClass);
+          };
 
-          // Add init class.
-          accordion.classList.add(initClass);
-
-          // Add show/hide button to each accordion pane title element.
-          title[0].children[0].innerHTML = '';
-          title[0].children[0].appendChild(button);
         }
       };
 
@@ -194,13 +197,18 @@
             .removeAttribute('id');
           
           // Hide buttons in accordion pane titles.
-          button.hidden = true;
+          if (button) {
+            button.hidden = true;
+          }
 
           // Un-hide default heading text
-          accordion
+          const heading =  accordion
             .querySelectorAll('.accordion-pane__title')[i]
-            .querySelector('.accordion-pane__heading')
-            .hidden = false
+            .querySelector('.accordion-pane__heading');
+
+          if (heading) {
+            heading.hidden = false;
+          }
 
           // Remove id attributes from pane content elements.
           accordionPanes[i]

--- a/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
+++ b/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
@@ -118,14 +118,18 @@
           const content = pane.querySelectorAll('.accordion-pane__content');
           const title = pane.querySelectorAll('.accordion-pane__title');
           const button = title[0].querySelector('button');
+          const heading = title[0].querySelector('.accordion-pane__heading');
           const id = `accordion-content-${index}-${i}`;
 
           // Add id attribute to all pane content elements.
           content[0].setAttribute('id', id);
 
-          // Add aria-controls id to button
-          button.hidden = false;
+          // Add aria-controls id to button and un-hide
           button.setAttribute('aria-controls', id);
+          button.hidden = false;
+
+          // Hide default Heading text
+          heading.hidden = true;
 
           // Add click event listener to the show/hide button.
           button.addEventListener('click', e => {
@@ -186,11 +190,17 @@
           // Remove id attributes from buttons in accordion pane titles.
           const button = accordion
             .querySelectorAll('.accordion-pane__title')[i]
-            .querySelectorAll('button')
+            .querySelector('button')
             .removeAttribute('id');
           
           // Hide buttons in accordion pane titles.
           button.hidden = true;
+
+          // Un-hide default heading text
+          accordion
+            .querySelectorAll('.accordion-pane__title')[i]
+            .querySelector('.accordion-pane__heading')
+            .hidden = false
 
           // Remove id attributes from pane content elements.
           accordionPanes[i]

--- a/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
+++ b/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
@@ -127,8 +127,6 @@
 
           // Add show/hide button to each accordion title.
           button.appendChild(text);
-          // Add an initially hidden icon which can be used if required to make accordions fit GDS standard
-          button.innerHTML += "<span class='accordion-icon' aria-hidden='true'></span>";
           button.setAttribute('aria-expanded', 'false');
           button.setAttribute('aria-controls', id);
 

--- a/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
+++ b/modules/localgov_subsites_paragraphs/js/localgov-accordion.js
@@ -117,7 +117,7 @@
           const pane = accordionPanes[i];
           const content = pane.querySelectorAll('.accordion-pane__content');
           const title = pane.querySelectorAll('.accordion-pane__title');
-          const button = title[0].querySelector('.accordion-pane-toggle');
+          const button = title[0].querySelector('button');
           const id = `accordion-content-${index}-${i}`;
 
           // Add id attribute to all pane content elements.

--- a/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.module
+++ b/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.module
@@ -122,6 +122,8 @@ function localgov_subsites_paragraphs_preprocess_paragraph(&$variables) {
     $heading_level = $paragraph->get('localgov_heading_level')->value;
     if (is_string($heading_level)) {
       $variables['heading'] = _localgov_subsites_paragraphs_create_heading($heading_text, $heading_level);
+      $variables['heading_text'] = $heading_text;
+      $variables['heading_level'] = $heading_level;
     }
   }
 

--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-accordion-pane.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-accordion-pane.html.twig
@@ -52,7 +52,12 @@
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
       <div class="accordion-pane__title">
-        <{{ heading_level }}>{{ heading_text }}<span class='accordion-icon' aria-hidden='true'></{{ heading_level }}>
+        <{{ heading_level }}>
+          <button aria-expanded="false">
+            {{ heading_text }}
+            <span class='accordion-icon' aria-hidden='true'></span>
+          </button>
+        </{{ heading_level }}>
       </div>
       <div class="accordion-pane__content">
         {{ content.localgov_body_text }}

--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-accordion-pane.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-accordion-pane.html.twig
@@ -52,7 +52,7 @@
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
       <div class="accordion-pane__title">
-        {{ heading }}
+        <{{ heading_level }}>{{ heading_text }}<span class='accordion-icon' aria-hidden='true'></{{ heading_level }}>
       </div>
       <div class="accordion-pane__content">
         {{ content.localgov_body_text }}

--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-accordion-pane.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-accordion-pane.html.twig
@@ -53,6 +53,7 @@
     {% block content %}
       <div class="accordion-pane__title">
         <{{ heading_level }}>
+          <span class="accordion-pane__heading">{{ heading_text }}</span>
           <button aria-expanded="false" hidden>
             {{ heading_text }}
             <span class='accordion-icon' aria-hidden='true'></span>

--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-accordion-pane.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-accordion-pane.html.twig
@@ -53,7 +53,7 @@
     {% block content %}
       <div class="accordion-pane__title">
         <{{ heading_level }}>
-          <button aria-expanded="false">
+          <button aria-expanded="false" hidden>
             {{ heading_text }}
             <span class='accordion-icon' aria-hidden='true'></span>
           </button>


### PR DESCRIPTION
The Accordion Pane icons are currently being added using Javascript, this strikes me as being bad practice therefore this PR removes them from being added via `localgov-accordion.js` and instead adds them via the Accordion Pane Twig file instead (`paragraph--localgov-accordion-pane.html.twig`)

See issue https://github.com/localgovdrupal/localgov_paragraphs/issues/199