### PR TITLE
updates help text for banner link field

### DIFF
--- a/modules/localgov_subsites_paragraphs/config/install/field.field.paragraph.localgov_banner_primary.localgov_url.yml
+++ b/modules/localgov_subsites_paragraphs/config/install/field.field.paragraph.localgov_banner_primary.localgov_url.yml
@@ -9,7 +9,7 @@ field_name: localgov_url
 entity_type: paragraph
 bundle: localgov_banner_primary
 label: URL
-description: 'An optional url. Adding a url here will make the whole box a link.'
+description: 'An optional url. Adding a url here will make the banner title a link.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.install
+++ b/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.install
@@ -13,7 +13,7 @@ use Drupal\field\Entity\FieldStorageConfig;
 /**
  * Implements hook_update_N().
  */
-function localgov_subsites_paragraphs_update_10001() {
+function localgov_subsites_paragraphs_update_10001():void {
   $paragraphType = 'localgov_accordion';
   $display = 'paragraph.' . $paragraphType . '.default';
   $existingFields = [
@@ -129,7 +129,7 @@ function localgov_subsites_paragraphs_update_10001() {
 /**
  * Update the description of the localgov_url field.
  */
-function localgov_subsites_paragraphs_update_10002() {
+function localgov_subsites_paragraphs_update_10002():void {
   // Update the description of the localgov_url field to match what we have
   // in config.
   $field = FieldConfig::loadByName('paragraph', 'localgov_banner_primary', 'localgov_url');

--- a/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.install
+++ b/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.install
@@ -125,3 +125,16 @@ function localgov_subsites_paragraphs_update_10001() {
     }
   }
 }
+
+/**
+ * Update the description of the localgov_url field.
+ */
+function localgov_subsites_paragraphs_update_10002() {
+  // Update the description of the localgov_url field to match what we have
+  // in config.
+  $field = FieldConfig::loadByName('paragraph', 'localgov_banner_primary', 'localgov_url');
+  if ($field) {
+    $field->setDescription(t('An optional url. Adding a url here will make the banner title a link.'));
+    $field->save();
+  }
+}


### PR DESCRIPTION
Closes #204 

## What does this change?

Updates the help text on the banner link field.

Note - this should only be merged _if_ we merge https://github.com/localgovdrupal/localgov_base/pull/662

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.