### PR TITLE
Update row order id, so last rows always delete #212

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
                 "Fix schema #3138668": "https://www.drupal.org/files/issues/2021-01-27/geolocation-google-maps-schema-update-3138668-5.patch"
             },
             "drupal/tablefield": {
-                "Fix PHP8.2 deprecation in Drupal tablefield, see https://www.drupal.org/project/tablefield/issues/3397688.": "https://www.drupal.org/files/issues/2023-12-21/tablefield-php8.2-deprecated-creation-of-dynamic-properties-3397688-9.patch"
+                "Fix PHP8.2 deprecation in Drupal tablefield, see https://www.drupal.org/project/tablefield/issues/3397688.": "https://www.drupal.org/files/issues/2023-12-21/tablefield-php8.2-deprecated-creation-of-dynamic-properties-3397688-9.patch",
+                "Row order identifiers localgov_paragraphs:#212 https://www.drupal.org/project/tablefield/issues/3441319": "https://www.drupal.org/files/issues/2024-05-03/tablefield-3441319-1.patch"
             }
         }
     }


### PR DESCRIPTION
Current patch only against this version. Haven't updated to the latest dev / rc because there seems to be some back and forth. Issue https://www.drupal.org/project/tablefield/issues/3441319 has branch that's up to date for dev.

## What does this change?

Presently when a table has had its rows moved around the internal stored row order isn't in sync. So when you delete rows the rows that _were_ at the bottem get deleted. Patch - see issue - fixes this.

## How to test

Create some content with a paragraph table. Add rows "1", "2", "3", "4". Move "4" to be second row. 'Change number of  rows/columns' to remove a row and 'Rebuild table'. Without patch "4" (now second row) is removed. With patch "3" (now forth row) will be removed.