### PR TITLE
2.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         "drupal/entity_usage": "^2.0@beta",
         "drupal/field_formatter_class": "^1.4",
         "drupal/field_group": "^3.0",
-        "drupal/fontawesome": "^2.18",
+        "drupal/fontawesome": "^3.0",
         "drupal/geolocation": "^3.1",
         "drupal/layout_paragraphs": "^2.0",
         "drupal/office_hours": "^1.8",
         "drupal/paragraphs": "^1.13",
-        "drupal/tablefield": "^2.3",
+        "drupal/tablefield": "^2.4 || ^3.0@beta",
         "drupal/viewsreference": "^2.0",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_topics": "^1.0"
@@ -32,9 +32,6 @@
         "patches": {
             "drupal/geolocation": {
                 "Fix schema #3138668": "https://www.drupal.org/files/issues/2021-01-27/geolocation-google-maps-schema-update-3138668-5.patch"
-            },
-            "drupal/tablefield": {
-                "Fix PHP8.2 deprecation in Drupal tablefield, see https://www.drupal.org/project/tablefield/issues/3397688.": "https://www.drupal.org/files/issues/2023-12-21/tablefield-php8.2-deprecated-creation-of-dynamic-properties-3397688-9.patch"
             }
         }
     }

--- a/localgov_paragraphs.info.yml
+++ b/localgov_paragraphs.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Paragraphs
 description: Provides core paragraph components for the LocalGov Drupal distribution.
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^10.2
+core_version_requirement: ^10.2 || ^11
 
 dependencies:
   # Drupal
@@ -22,7 +22,7 @@ dependencies:
   - geolocation:geolocation_google_maps
   - geolocation:geolocation_leaflet
   - office_hours:office_hours
-  - paragraphs:paragraphs (>=8.x-1.13)
+  - paragraphs:paragraphs
   - paragraphs:paragraphs_library
   # LocalGovDrupal
   - localgov_core:localgov_media

--- a/modules/localgov_homepage_paragraphs/localgov_homepage_paragraphs.info.yml
+++ b/modules/localgov_homepage_paragraphs/localgov_homepage_paragraphs.info.yml
@@ -2,7 +2,7 @@ type: module
 name: LocalGov Drupal homepage paragraphs
 description: Paragraph bundles used in the LocalGov Drupal homepage.
 package: LocalGov Drupal
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   # Drupal core modules.
   - drupal:link

--- a/modules/localgov_homepage_paragraphs/tests/modules/localgov_homepage_paragraphs_dummy_content_type/localgov_homepage_paragraphs_dummy_content_type.info.yml
+++ b/modules/localgov_homepage_paragraphs/tests/modules/localgov_homepage_paragraphs_dummy_content_type/localgov_homepage_paragraphs_dummy_content_type.info.yml
@@ -2,7 +2,7 @@ type: module
 name: Dummy homepage
 description: A dummy Homepage content type.
 package: LocalGovDrupal
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   # Core modules
   - drupal:path

--- a/modules/localgov_paragraphs_layout/localgov_paragraphs_layout.info.yml
+++ b/modules/localgov_paragraphs_layout/localgov_paragraphs_layout.info.yml
@@ -2,7 +2,7 @@ type: module
 name: LocalGov Drupal layouts
 description: Layouts used in the LocalGov Drupal page
 package: LocalGov Drupal
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:menu_ui
   - layout_paragraphs:layout_paragraphs

--- a/modules/localgov_paragraphs_views/localgov_paragraphs_views.info.yml
+++ b/modules/localgov_paragraphs_views/localgov_paragraphs_views.info.yml
@@ -2,7 +2,7 @@ type: module
 name: LocalGov Drupal Paragraphs Views
 description: Paragraphs referencing views
 package: LocalGov Drupal
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - viewsreference:viewsreference
   - localgov_paragraphs:localgov_subsites_paragraphs

--- a/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.info.yml
+++ b/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.info.yml
@@ -1,6 +1,6 @@
 name: LocalGov Subsites Paragraphs
 description: Page builder paragraph types for use with LocalGov Subsites.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 package: LocalGov Drupal
 


### PR DESCRIPTION
Adds Drupal 11 support.

Note: Upgrades fontawesome to recommended 3.x; Allows tablefield to upgrade to 3.x