### PR TITLE
fix: return type hint spacing

### DIFF
--- a/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.install
+++ b/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.install
@@ -13,7 +13,7 @@ use Drupal\field\Entity\FieldStorageConfig;
 /**
  * Implements hook_update_N().
  */
-function localgov_subsites_paragraphs_update_10001():void {
+function localgov_subsites_paragraphs_update_10001(): void {
   $paragraphType = 'localgov_accordion';
   $display = 'paragraph.' . $paragraphType . '.default';
   $existingFields = [
@@ -129,7 +129,7 @@ function localgov_subsites_paragraphs_update_10001():void {
 /**
  * Update the description of the localgov_url field.
  */
-function localgov_subsites_paragraphs_update_10002():void {
+function localgov_subsites_paragraphs_update_10002(): void {
   // Update the description of the localgov_url field to match what we have
   // in config.
   $field = FieldConfig::loadByName('paragraph', 'localgov_banner_primary', 'localgov_url');


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes spacing issues with the return type hint. Getting ahead of these now before the Drupal coding standards change is implemented to check for this.