### PR TITLE
Update Tablefield patch so that it works with Tablefield 2.x and 3.x …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "drupal/layout_paragraphs": "^2.0",
         "drupal/office_hours": "^1.8",
         "drupal/paragraphs": "^1.13",
-        "drupal/tablefield": "^2.4 || ^3.0@beta",
+        "drupal/tablefield": "^3.0@beta",
         "drupal/viewsreference": "^2.0",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_topics": "^1.0"
@@ -34,7 +34,7 @@
                 "Fix schema #3138668": "https://www.drupal.org/files/issues/2021-01-27/geolocation-google-maps-schema-update-3138668-5.patch"
             },
             "drupal/tablefield": {
-                "Row order identifiers localgov_paragraphs:#212 https://www.drupal.org/project/tablefield/issues/3441319": "https://www.drupal.org/files/issues/2024-05-03/tablefield-3441319-1.patch"
+                "Row order identifiers localgov_paragraphs:#212 https://www.drupal.org/project/tablefield/issues/3441319": "https://www.drupal.org/files/issues/2025-02-14/3441319-19.patch"
             }
         }
     }


### PR DESCRIPTION
…(#222)

* Update Tablefield patch so that it works with Tablefield 2.x and 3.x #221

* Update composer.json to taget 3.0@beta

---------

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)