### PR TITLE
Pin office_hours to 1.23 to avoid fatal php error.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/fontawesome": "^3.0",
         "drupal/geolocation": "^3.1",
         "drupal/layout_paragraphs": "^2.0",
-        "drupal/office_hours": "^1.8",
+        "drupal/office_hours": "1.23",
         "drupal/paragraphs": "^1.13",
         "drupal/tablefield": "^3.0@beta",
         "drupal/viewsreference": "^2.0",


### PR DESCRIPTION
https://github.com/localgovdrupal/localgov_paragraphs/issues/232

Also see 

https://www.drupal.org/project/office_hours/issues/3514975

and 

https://www.drupal.org/project/office_hours/issues/3514974