### PR TITLE
Fix WSOD if referenced media gets deleted

### DIFF
--- a/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.module
+++ b/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.module
@@ -143,7 +143,7 @@ function localgov_subsites_paragraphs_preprocess_paragraph(&$variables) {
       $button = $paragraph->get('localgov_button')->first()->getValue();
       $variables['button_url'] = Url::fromUri($button['uri']);
     }
-    if (!$paragraph->get('localgov_background_image')->isEmpty()) {
+    if ($paragraph->get('localgov_background_image')->entity) {
       $fid = $paragraph->get('localgov_background_image')->entity->field_media_image[0]->getValue()['target_id'];
       $file_url = File::load($fid)->getFileUri();
 


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?
- `Call Out Box` paragraph, found under `localgov_subsites_paragraphs` uses a media field named `localgov_background_image`.
- Data from that field is then loaded in
https://github.com/localgovdrupal/localgov_paragraphs/blob/f270b7aa9b26d5abc5a0eb2cd387657c2abe1d38/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.module#L147
- If a media file that is used in `Call Out Box` gets deleted then the site results in a WSOD and the user can't view or edit the node in order to fix it.

Checking if the field is empty:
https://github.com/localgovdrupal/localgov_paragraphs/blob/f270b7aa9b26d5abc5a0eb2cd387657c2abe1d38/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.module#L146
is not correct in this case, as we should be checking if the entity actually exists

## How to test

1. Add a node with a call out box with a media
2. See the node
3. Delete the media from the media library
4. See the node -> you get a PHP error

## How can we measure success?

Deleting a media doesn't break the page