### PR TITLE
Pin Office Hours to 1.28

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/fontawesome": "^3.0",
         "drupal/geolocation": "^3.1",
         "drupal/layout_paragraphs": "^2.0",
-        "drupal/office_hours": "1.27",
+        "drupal/office_hours": "1.28",
         "drupal/paragraphs": "^1.13",
         "drupal/tablefield": "^3.0@beta",
         "drupal/viewsreference": "^2.0",


### PR DESCRIPTION
See https://github.com/localgovdrupal/localgov_paragraphs/issues/232
And https://github.com/localgovdrupal/localgov_paragraphs/pull/243

This PR pins Office Hours to the latest stable version (v1.28)