### PR TITLE
fix: missing dependencies causing d11 tests to fail

### DIFF
--- a/localgov_paragraphs.info.yml
+++ b/localgov_paragraphs.info.yml
@@ -27,5 +27,6 @@ dependencies:
   - paragraphs:paragraphs
   - paragraphs:paragraphs_library
   # LocalGovDrupal
+  - localgov_core:localgov_core
   - localgov_core:localgov_media
   - localgov_topics:localgov_topics

--- a/localgov_paragraphs.info.yml
+++ b/localgov_paragraphs.info.yml
@@ -6,8 +6,10 @@ core_version_requirement: ^10.2 || ^11
 
 dependencies:
   # Drupal
+  - drupal:filter
   - drupal:field
   - drupal:link
+  - drupal:media
   - drupal:options
   - drupal:taxonomy
   - drupal:telephone

--- a/modules/localgov_homepage_paragraphs/localgov_homepage_paragraphs.info.yml
+++ b/modules/localgov_homepage_paragraphs/localgov_homepage_paragraphs.info.yml
@@ -16,4 +16,5 @@ dependencies:
   - fontawesome:fontawesome
   - paragraphs:paragraphs
   # LocalGov Drupal modules.
+  - localgov_core:localgov_core
   - localgov_core:localgov_media

--- a/modules/localgov_homepage_paragraphs/localgov_homepage_paragraphs.info.yml
+++ b/modules/localgov_homepage_paragraphs/localgov_homepage_paragraphs.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^10 || ^11
 dependencies:
   # Drupal core modules.
   - drupal:link
+  - drupal:media
   - drupal:node
   - drupal:options
   - drupal:responsive_image

--- a/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.info.yml
+++ b/modules/localgov_subsites_paragraphs/localgov_subsites_paragraphs.info.yml
@@ -5,6 +5,7 @@ type: module
 package: LocalGov Drupal
 
 dependencies:
+  - drupal:filter
   - drupal:media
   - drupal:options
   - paragraphs:paragraphs

--- a/tests/src/Functional/ContactEditTest.php
+++ b/tests/src/Functional/ContactEditTest.php
@@ -17,6 +17,10 @@ class ContactEditTest extends BrowserTestBase {
    * @var array
    */
   protected static $modules = [
+    'filter',
+    'media',
+    'localgov_core',
+    'localgov_media',
     'localgov_paragraphs',
     'paragraphs_library',
   ];

--- a/tests/src/Functional/ParagraphsAdministrationTest.php
+++ b/tests/src/Functional/ParagraphsAdministrationTest.php
@@ -28,6 +28,10 @@ class ParagraphsAdministrationTest extends ParagraphsTestBase {
    * @var array
    */
   protected static $modules = [
+    'filter',
+    'media',
+    'localgov_core',
+    'localgov_media',
     'localgov_paragraphs',
   ];
 


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)