### PR TITLE
fix: testing on Drupal 11.2 by testing with the localgov profile

### DIFF
--- a/tests/src/Functional/ContactEditTest.php
+++ b/tests/src/Functional/ContactEditTest.php
@@ -23,6 +23,11 @@ class ContactEditTest extends BrowserTestBase {
 
   /**
    * {@inheritdoc}
+   */
+  protected $profile = 'localgov';
+
+  /**
+   * {@inheritdoc}
    *
    * Claro is throwing the exception.
    */

--- a/tests/src/Functional/ParagraphsAdministrationTest.php
+++ b/tests/src/Functional/ParagraphsAdministrationTest.php
@@ -32,6 +32,11 @@ class ParagraphsAdministrationTest extends ParagraphsTestBase {
   ];
 
   /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'localgov';
+
+  /**
    * Tests the LocalGovDrupal core paragraph types.
    */
   public function testParagraphsTypes() {


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes #247 by running tests with the localgov profile, this is the same as other modules that run tests

Note: This will need testing locally as the pipeline only tests 11.1.x and not 11.2+