### PR TITLE
Fix: Layout conflict

### DIFF
--- a/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/fourcol-25-25-25-25.css
+++ b/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/fourcol-25-25-25-25.css
@@ -1,9 +1,9 @@
 /*
  * @file
- * Provides the layout styles for layout_threecol_33_34_33.
+ * Provides the layout styles for localgov_layout_fourcol_33_34_33.
  */
 
-.layout--fourcol-25-25-25-25 {
+.layout--localgov-fourcol-25-25-25-25 {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--fourcol-25-25-25-25 > .layout__region {
+.layout--localgov-fourcol-25-25-25-25 > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--fourcol-25-25-25-25 {
+  .layout--localgov-fourcol-25-25-25-25 {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.
@@ -30,7 +30,7 @@
 }
 
 @media screen and (min-width: 60em) {
-  .layout--fourcol-25-25-25-25 {
+  .layout--localgov-fourcol-25-25-25-25 {
     grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/fourcol-25-25-25-25.css
+++ b/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/fourcol-25-25-25-25.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_fourcol_33_34_33.
  */
 
-.layout--fourcol.layout--fourcol-25-25-25-25--localgov {
+.layout--localgov-fourcol-25-25-25-25 {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--fourcol.layout--fourcol-25-25-25-25--localgov > .layout__region {
+.layout--localgov-fourcol-25-25-25-25 > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--fourcol.layout--fourcol-25-25-25-25--localgov {
+  .layout--localgov-fourcol-25-25-25-25 {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.
@@ -30,7 +30,7 @@
 }
 
 @media screen and (min-width: 60em) {
-  .layout--fourcol.layout--fourcol-25-25-25-25--localgov {
+  .layout--localgov-fourcol-25-25-25-25 {
     grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/fourcol-25-25-25-25.css
+++ b/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/fourcol-25-25-25-25.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_fourcol_33_34_33.
  */
 
-.layout--localgov-fourcol-25-25-25-25 {
+.layout--fourcol.layout--fourcol-25-25-25-25--localgov {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--localgov-fourcol-25-25-25-25 > .layout__region {
+.layout--fourcol.layout--fourcol-25-25-25-25--localgov > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--localgov-fourcol-25-25-25-25 {
+  .layout--fourcol.layout--fourcol-25-25-25-25--localgov {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.
@@ -30,7 +30,7 @@
 }
 
 @media screen and (min-width: 60em) {
-  .layout--localgov-fourcol-25-25-25-25 {
+  .layout--fourcol.layout--fourcol-25-25-25-25--localgov {
     grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/fourcol-25-25-25-25.css
+++ b/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/fourcol-25-25-25-25.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_fourcol_33_34_33.
  */
 
-.layout--fourcol.layout--fourcol-25-25-25-25--localgov {
+.layout--fourcol-25-25-25-25--localgov {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--fourcol.layout--fourcol-25-25-25-25--localgov > .layout__region {
+.layout--fourcol-25-25-25-25--localgov > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--fourcol.layout--fourcol-25-25-25-25--localgov {
+  .layout--fourcol-25-25-25-25--localgov {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.
@@ -30,7 +30,7 @@
 }
 
 @media screen and (min-width: 60em) {
-  .layout--fourcol.layout--fourcol-25-25-25-25--localgov {
+  .layout--fourcol-25-25-25-25--localgov {
     grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/fourcol-25-25-25-25.css
+++ b/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/fourcol-25-25-25-25.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_fourcol_33_34_33.
  */
 
-.layout--fourcol-25-25-25-25--localgov {
+.layout--fourcol.layout--fourcol-25-25-25-25--localgov {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--fourcol-25-25-25-25--localgov > .layout__region {
+.layout--fourcol.layout--fourcol-25-25-25-25--localgov > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--fourcol-25-25-25-25--localgov {
+  .layout--fourcol.layout--fourcol-25-25-25-25--localgov {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.
@@ -30,7 +30,7 @@
 }
 
 @media screen and (min-width: 60em) {
-  .layout--fourcol-25-25-25-25--localgov {
+  .layout--fourcol.layout--fourcol-25-25-25-25--localgov {
     grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/layout--localgov-fourcol-25-25-25-25.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/layout--localgov-fourcol-25-25-25-25.html.twig
@@ -1,10 +1,9 @@
 {#
 /**
  * @file
- * Default theme implementation for a three column layout.
+ * Default theme implementation for a four column layout.
  *
- * This template provides a three column 33%-34%-33% display layout, with
- * additional areas for the top and the bottom.
+ * This template provides a four column 25%-25%-25%-25% display layout.
  *
  * Available variables:
  * - content: The content for this layout.
@@ -16,7 +15,7 @@
 {%
   set classes = [
     'layout',
-    'layout--fourcol-25-25-25-25',
+    'layout--localgov-fourcol-25-25-25-25',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/layout--localgov-fourcol-25-25-25-25.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/layout--localgov-fourcol-25-25-25-25.html.twig
@@ -16,7 +16,6 @@
   set classes = [
     'layout',
     'layout--fourcol',
-    'layout--fourcol-25-25-25-25',
     'layout--fourcol-25-25-25-25--localgov',
   ]
 %}

--- a/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/layout--localgov-fourcol-25-25-25-25.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/layout--localgov-fourcol-25-25-25-25.html.twig
@@ -15,7 +15,8 @@
 {%
   set classes = [
     'layout',
-    'layout--localgov-fourcol-25-25-25-25',
+    'layout--fourcol',
+    'layout--fourcol-25-25-25-25--localgov',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/layout--localgov-fourcol-25-25-25-25.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/layout--localgov-fourcol-25-25-25-25.html.twig
@@ -15,8 +15,7 @@
 {%
   set classes = [
     'layout',
-    'layout--fourcol',
-    'layout--fourcol-25-25-25-25--localgov',
+    'layout--localgov-fourcol-25-25-25-25',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/layout--localgov-fourcol-25-25-25-25.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/fourcol/fourcol_25_25_25_25/layout--localgov-fourcol-25-25-25-25.html.twig
@@ -16,6 +16,7 @@
   set classes = [
     'layout',
     'layout--fourcol',
+    'layout--fourcol-25-25-25-25',
     'layout--fourcol-25-25-25-25--localgov',
   ]
 %}

--- a/modules/localgov_paragraphs_layout/layouts/onecol/layout--localgov-onecol.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/onecol/layout--localgov-onecol.html.twig
@@ -13,7 +13,8 @@
 {%
   set classes = [
     'layout',
-    'layout--localgov-onecol',
+    'layout--onecol',
+    'layout--onecol--localgov',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/onecol/layout--localgov-onecol.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/onecol/layout--localgov-onecol.html.twig
@@ -13,8 +13,7 @@
 {%
   set classes = [
     'layout',
-    'layout--onecol',
-    'layout--onecol--localgov',
+    'layout--localgov-onecol',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/onecol/layout--localgov-onecol.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/onecol/layout--localgov-onecol.html.twig
@@ -13,7 +13,7 @@
 {%
   set classes = [
     'layout',
-    'layout--onecol',
+    'layout--localgov-onecol',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/onecol/onecol.css
+++ b/modules/localgov_paragraphs_layout/layouts/onecol/onecol.css
@@ -2,6 +2,6 @@
  * @file
  * Provides the layout styles for localgov_layout_onecol.
  */
-.layout--onecol--localgov .layout__region {
+.layout--onecol.layout--onecol--localgov .layout__region {
   width: 100%;
 }

--- a/modules/localgov_paragraphs_layout/layouts/onecol/onecol.css
+++ b/modules/localgov_paragraphs_layout/layouts/onecol/onecol.css
@@ -2,6 +2,6 @@
  * @file
  * Provides the layout styles for localgov_layout_onecol.
  */
-.layout--localgov-onecol .layout__region {
+.layout--onecol.layout--onecol--localgov .layout__region {
   width: 100%;
 }

--- a/modules/localgov_paragraphs_layout/layouts/onecol/onecol.css
+++ b/modules/localgov_paragraphs_layout/layouts/onecol/onecol.css
@@ -1,7 +1,7 @@
 /*
  * @file
- * Provides the layout styles for layout_onecol.
+ * Provides the layout styles for localgov_layout_onecol.
  */
-.layout--onecol .layout__region {
+.layout--localgov-onecol .layout__region {
   width: 100%;
 }

--- a/modules/localgov_paragraphs_layout/layouts/onecol/onecol.css
+++ b/modules/localgov_paragraphs_layout/layouts/onecol/onecol.css
@@ -2,6 +2,6 @@
  * @file
  * Provides the layout styles for localgov_layout_onecol.
  */
-.layout--onecol.layout--onecol--localgov .layout__region {
+.layout--onecol--localgov .layout__region {
   width: 100%;
 }

--- a/modules/localgov_paragraphs_layout/layouts/onecol/onecol.css
+++ b/modules/localgov_paragraphs_layout/layouts/onecol/onecol.css
@@ -2,6 +2,6 @@
  * @file
  * Provides the layout styles for localgov_layout_onecol.
  */
-.layout--onecol.layout--onecol--localgov .layout__region {
+.layout--localgov-onecol .layout__region {
   width: 100%;
 }

--- a/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/layout--localgov-threecol-33-34-33.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/layout--localgov-threecol-33-34-33.html.twig
@@ -15,8 +15,7 @@
 {%
   set classes = [
     'layout',
-    'layout--threecol',
-    'layout--threecol-33-34-33--localgov',
+    'layout--localgov-threecol-33-34-33',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/layout--localgov-threecol-33-34-33.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/layout--localgov-threecol-33-34-33.html.twig
@@ -16,7 +16,6 @@
   set classes = [
     'layout',
     'layout--threecol',
-    'layout--threecol-33-34-33',
     'layout--threecol-33-34-33--localgov',
   ]
 %}

--- a/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/layout--localgov-threecol-33-34-33.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/layout--localgov-threecol-33-34-33.html.twig
@@ -16,6 +16,7 @@
   set classes = [
     'layout',
     'layout--threecol',
+    'layout--threecol-33-34-33',
     'layout--threecol-33-34-33--localgov',
   ]
 %}

--- a/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/layout--localgov-threecol-33-34-33.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/layout--localgov-threecol-33-34-33.html.twig
@@ -3,8 +3,7 @@
  * @file
  * Default theme implementation for a three column layout.
  *
- * This template provides a three column 33%-34%-33% display layout, with
- * additional areas for the top and the bottom.
+ * This template provides a three column 33%-34%-33% display layout.
  *
  * Available variables:
  * - content: The content for this layout.
@@ -16,7 +15,7 @@
 {%
   set classes = [
     'layout',
-    'layout--threecol-33-34-33',
+    'layout--localgov-threecol-33-34-33',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/layout--localgov-threecol-33-34-33.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/layout--localgov-threecol-33-34-33.html.twig
@@ -15,7 +15,8 @@
 {%
   set classes = [
     'layout',
-    'layout--localgov-threecol-33-34-33',
+    'layout--threecol',
+    'layout--threecol-33-34-33--localgov',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/threecol_33_34_33.css
+++ b/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/threecol_33_34_33.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_threecol_33_34_33.
  */
 
-.layout--threecol.layout--threecol-33-34-33--localgov {
+.layout--localgov-threecol-33-34-33 {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--threecol.layout--threecol-33-34-33--localgov > .layout__region {
+.layout--localgov-threecol-33-34-33 > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--threecol.layout--threecol-33-34-33--localgov {
+  .layout--localgov-threecol-33-34-33 {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.

--- a/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/threecol_33_34_33.css
+++ b/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/threecol_33_34_33.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_threecol_33_34_33.
  */
 
-.layout--threecol-33-34-33--localgov {
+.layout--threecol.layout--threecol-33-34-33--localgov {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--threecol-33-34-33--localgov > .layout__region {
+.layout--threecol.layout--threecol-33-34-33--localgov > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--threecol-33-34-33--localgov {
+  .layout--threecol.layout--threecol-33-34-33--localgov {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.

--- a/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/threecol_33_34_33.css
+++ b/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/threecol_33_34_33.css
@@ -1,9 +1,9 @@
 /*
  * @file
- * Provides the layout styles for layout_threecol_33_34_33.
+ * Provides the layout styles for localgov_layout_threecol_33_34_33.
  */
 
-.layout--threecol-33-34-33 {
+.layout--localgov-threecol-33-34-33 {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--threecol-33-34-33 > .layout__region {
+.layout--localgov-threecol-33-34-33 > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--threecol-33-34-33 {
+  .layout--localgov-threecol-33-34-33 {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.

--- a/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/threecol_33_34_33.css
+++ b/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/threecol_33_34_33.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_threecol_33_34_33.
  */
 
-.layout--localgov-threecol-33-34-33 {
+.layout--threecol.layout--threecol-33-34-33--localgov {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--localgov-threecol-33-34-33 > .layout__region {
+.layout--threecol.layout--threecol-33-34-33--localgov > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--localgov-threecol-33-34-33 {
+  .layout--threecol.layout--threecol-33-34-33--localgov {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.

--- a/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/threecol_33_34_33.css
+++ b/modules/localgov_paragraphs_layout/layouts/threecol_33_34_33/threecol_33_34_33.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_threecol_33_34_33.
  */
 
-.layout--threecol.layout--threecol-33-34-33--localgov {
+.layout--threecol-33-34-33--localgov {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--threecol.layout--threecol-33-34-33--localgov > .layout__region {
+.layout--threecol-33-34-33--localgov > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--threecol.layout--threecol-33-34-33--localgov {
+  .layout--threecol-33-34-33--localgov {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.

--- a/modules/localgov_paragraphs_layout/layouts/twocol/layout--localgov-twocol.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/twocol/layout--localgov-twocol.html.twig
@@ -13,8 +13,7 @@
 {%
   set classes = [
     'layout',
-    'layout--twocol',
-    'layout--twocol--localgov',
+    'layout--localgov-twocol',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/twocol/layout--localgov-twocol.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/twocol/layout--localgov-twocol.html.twig
@@ -13,7 +13,8 @@
 {%
   set classes = [
     'layout',
-    'layout--localgov-twocol',
+    'layout--twocol',
+    'layout--twocol--localgov',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/twocol/layout--localgov-twocol.html.twig
+++ b/modules/localgov_paragraphs_layout/layouts/twocol/layout--localgov-twocol.html.twig
@@ -13,7 +13,7 @@
 {%
   set classes = [
     'layout',
-    'layout--twocol',
+    'layout--localgov-twocol',
   ]
 %}
 {% if content %}

--- a/modules/localgov_paragraphs_layout/layouts/twocol/twocol.css
+++ b/modules/localgov_paragraphs_layout/layouts/twocol/twocol.css
@@ -1,9 +1,9 @@
 /*
  * @file
- * Provides the layout styles for layout_twocol.
+ * Provides the layout styles for localgov_layout_twocol.
  */
 
-.layout--twocol {
+.layout--localgov-twocol {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--twocol > .layout__region {
+.layout--localgov-twocol > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--twocol {
+  .layout--localgov-twocol {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.

--- a/modules/localgov_paragraphs_layout/layouts/twocol/twocol.css
+++ b/modules/localgov_paragraphs_layout/layouts/twocol/twocol.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_twocol.
  */
 
-.layout--localgov-twocol {
+.layout--twocol.layout--twocol--localgov {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--localgov-twocol > .layout__region {
+.layout--twocol.layout--twocol--localgov > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--localgov-twocol {
+  .layout--twocol.layout--twocol--localgov {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.

--- a/modules/localgov_paragraphs_layout/layouts/twocol/twocol.css
+++ b/modules/localgov_paragraphs_layout/layouts/twocol/twocol.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_twocol.
  */
 
-.layout--twocol--localgov {
+.layout--twocol.layout--twocol--localgov {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--twocol--localgov > .layout__region {
+.layout--twocol.layout--twocol--localgov > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--twocol--localgov {
+  .layout--twocol.layout--twocol--localgov {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.

--- a/modules/localgov_paragraphs_layout/layouts/twocol/twocol.css
+++ b/modules/localgov_paragraphs_layout/layouts/twocol/twocol.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_twocol.
  */
 
-.layout--twocol.layout--twocol--localgov {
+.layout--twocol--localgov {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--twocol.layout--twocol--localgov > .layout__region {
+.layout--twocol--localgov > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--twocol.layout--twocol--localgov {
+  .layout--twocol--localgov {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.

--- a/modules/localgov_paragraphs_layout/layouts/twocol/twocol.css
+++ b/modules/localgov_paragraphs_layout/layouts/twocol/twocol.css
@@ -3,7 +3,7 @@
  * Provides the layout styles for localgov_layout_twocol.
  */
 
-.layout--twocol.layout--twocol--localgov {
+.layout--localgov-twocol {
   --lgd-page-section-gap: 0;
 
   display: grid;
@@ -11,13 +11,13 @@
   gap: var(--lgd-page-section-gap);
 }
 
-.layout--twocol.layout--twocol--localgov > .layout__region {
+.layout--localgov-twocol > .layout__region {
   /* To equalise the heights in each row */
   display: grid;
 }
 
 @media screen and (min-width: 40em) {
-  .layout--twocol.layout--twocol--localgov {
+  .layout--localgov-twocol {
     /*
       If you need to add some gap between items here, you can set the
       --lgd-page-section-gap variable to whatever gap size you need.


### PR DESCRIPTION
## What does this change?
Layouts from the localgov_paragraphs_layout submodule (e.g. Two column (simple)) are experiencing conflict with similar core layouts (e.g. Two column).  This is because these layouts are using the same CSS selectors as the core ones (e.g. `.layout--twocol`).  Renaming these CSS selectors resolves this.

## How to test
1. Enable the [publications module](https://github.com/localgovdrupal/localgov_) or the [subsites module](https://github.com/localgovdrupal/localgov_subsites) where you can use layouts.
2. From `Configuration > Content authoring > Layout paragraphs settings > Layout sections` (i.e. `/admin/config/content/layout_paragraphs/sections`), enable these layouts: Two column, Three column 25/50/25, Three column 33/34/33, Two column (simple), and Three column 33/34/33 (simple).  The last two of these layouts are provided by the localgov_paragraphs_layout submodule.
3. Add a subsite page or publication page and in that page select both the "Two column" and "Two column (simple)" layouts.  Add images (or any other paragraphs) to all available regions of these layouts.
4. Repeat the same for Three column 25/50/25, Three column 33/34/33, and Three column 33/34/33 (simple) layouts on a separate page.
5. The layouts should act as expected.

Resolves #260 