### PR TITLE
adds options for 3 or 4 items in box links listing

### DIFF
--- a/modules/localgov_subsites_paragraphs/config/install/field.storage.paragraph.localgov_box_listing_theme.yml
+++ b/modules/localgov_subsites_paragraphs/config/install/field.storage.paragraph.localgov_box_listing_theme.yml
@@ -11,11 +11,17 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: grid
-      label: Grid
-    -
       value: boxes
-      label: Boxes
+      label: 'Column (1 per row)'
+    -
+      value: grid
+      label: 'Grid (2 per row)'
+    -
+      value: grid-3
+      label: 'Grid (3 per row)'
+    -
+      value: grid-4
+      label: 'Grid (4 per row)'
   allowed_values_function: ''
 module: options
 locked: false


### PR DESCRIPTION
Closes #265

## What does this change?

- Adds an option for 3 or 4 items in a grid in box links listings. Currently you can only have 1 or two items.

## How to test

- Will need this PR from LocalGov Base to work: https://github.com/localgovdrupal/localgov_base/pull/887

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.